### PR TITLE
fix: prevent revealing cards before voting

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: Zyzle
+ko_fi: zyzle

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+## Description
+
+<!-- Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. -->
+
+Resolves #
+
+---
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor
+- [ ] Documentation update
+- [ ] Other (please describe):
+
+---
+
+## How Has This Been Tested?
+
+<!-- Please describe the tests that you ran to verify your changes. Include any relevant details for your test configuration. -->
+
+- [ ] Local build
+- [ ] Manual testing
+
+---
+
+## Checklist
+
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing tests pass locally with my changes
+
+---
+
+## Screenshots (if applicable)
+
+<!-- Drag and drop screenshots here or remove this section if not needed. -->
+
+---
+
+## Additional context
+
+<!-- Add any other context about the pull request

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,13 @@ on:
     paths:
       - "frontend/**"
       - "!**/*.md"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "frontend/**"
+      - "!**/*.md"
+    types: [opened, synchronize, reopened]
 
 jobs:
   chromatic:

--- a/.github/workflows/clippy-lint.yml
+++ b/.github/workflows/clippy-lint.yml
@@ -13,5 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache dependencies
+        id: cache-cargo-target
+        uses: actions/cache@v4
+        env:
+          cache-name: cargo-cache-target
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Run Clippy
         run: cargo clippy

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -13,7 +13,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - name: Install dependencies
+      - name: Cache dependencies
+        id: cache-node-modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-build-${{env.cache-name}}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{env.cache-name}}-${{ hashFiles('frontend/bun.lock') }}
+      - if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+        name: Install dependencies
         run: bun install
         working-directory: frontend
       - name: Run lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# How to contribute
+
+First off, thanks for taking an interest in the project!
+
+## Submitting a pull request
+
+Please submit pull requests to [Storypoint Shuffle](https://github.com/Zyzle/storypoint-shuffle/pull/new/master) with a clear description of the changes you've made. Ensure your commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines, including a `resolves: #<issue number>` footer if your change relates to an open issue. Please follow the coding conventions (below).
+
+## Coding conventions
+
+This is open source software. Consider the people who will read your code, and make it look nice for them.
+
+### Frontend
+
+- Respect the prettier formatting rules
+- Ensure the changes pass eslint rules
+- Any changes made that alter the above should detail these alterations and provide a justification (I'm fairly flexible when it comes to these but you may be asked to revise if I dont like them)
+- New components should ideally come with their own associated [Storybook](https://storybook.js.org/docs/writing-stories) files
+- Any visual changes will need to be approved before merging, this will happen via Chromatic
+
+### Backend
+
+- Please run `cargo fmt` before submitting
+- Ensure Rust code passes the configured clippy lints with `cargo clippy`
+- As above, changes to either of these policies will be approved or rejected at my digression

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+Currently we only provide support to the HEAD version of the git repository. Backports may be planned in future if we move to a tagged release model.
+
+## Reporting a Vulnerability
+
+Please do not report vulnerabilities publicly.
+
+Security related issues should be reported via email to [Security Reporting](mailto:security@zyzle.dev), I'll do my best to reply to and action these as quickly as possible.
+
+Use the following message template if possible:
+
+**Subject:** [SECURITY] Storypoint Shuffle
+
+**Body:**
+Description of the issue:
+
+Reproduction steps (if applicable):
+
+Potential impact (if known):

--- a/frontend/src/components/central-card.component.tsx
+++ b/frontend/src/components/central-card.component.tsx
@@ -13,6 +13,8 @@ function CentralCard({
   onVotesRevealed: () => void;
   onVotesReset: () => void;
 }) {
+  const hasSomeVoted = votes.length > 0;
+
   const voteCounts = votes.reduce(
     (acc, vote) => {
       acc[vote] = (acc[vote] || 0) + 1;
@@ -50,6 +52,7 @@ function CentralCard({
           <button
             onClick={onVotesRevealed}
             className="btn preset-filled-secondary-400-600 shadow-md"
+            disabled={!hasSomeVoted || isRevealed}
           >
             Reveal Cards
           </button>

--- a/frontend/src/components/central-card.stories.ts
+++ b/frontend/src/components/central-card.stories.ts
@@ -32,6 +32,16 @@ export const HiddenWithHostControls: Story = {
   },
 };
 
+export const HostControlsSomeVoted: Story = {
+  args: {
+    isRevealed: false,
+    showHostControls: true,
+    votes: [5],
+    onVotesRevealed: fn(),
+    onVotesReset: fn(),
+  },
+};
+
 export const VotesRevealed: Story = {
   args: {
     isRevealed: true,

--- a/frontend/src/routes/room.$roomId.tsx
+++ b/frontend/src/routes/room.$roomId.tsx
@@ -38,24 +38,30 @@ function Room() {
   const navigate = useNavigate();
   const isHost = useMemo(() => me?.id === room?.host_id, [me, room]);
   const [showConfetti, setShowConfetti] = useState(false);
+  const votes = useMemo(() => {
+    return room?.players
+      ? Object.values(room.players)
+          .map((p) => p.vote)
+          .filter((x) => x !== null)
+      : [];
+  }, [room]);
+  const isRevealed = useMemo(
+    () => room?.cards_revealed ?? false,
+    [room?.cards_revealed],
+  );
 
   useEffect(() => {
     const agreement =
-      room?.cards_revealed && room
+      isRevealed && room
         ? Object.values(room.players).every(
             (p) => p.vote === Object.values(room.players)[0].vote,
           )
         : false;
     setShowConfetti(agreement);
-  }, [room, setShowConfetti, room?.cards_revealed]);
+  }, [room, setShowConfetti, isRevealed]);
 
   const players = room ? Object.values(room.players) : [];
   const numPlayers = players.length;
-  const votes = room?.cards_revealed
-    ? Object.values(room.players)
-        .map((p) => p.vote)
-        .filter((x) => x !== null)
-    : [];
 
   const radius = 250;
   const centerOffset = 250;
@@ -80,7 +86,7 @@ function Room() {
         <div className="relative w-[500px] h-[500px] flex items-center justify-center">
           {/* Central Card for Average Vote */}
           <CentralCard
-            isRevealed={room?.cards_revealed ?? false}
+            isRevealed={isRevealed}
             showHostControls={isHost}
             votes={votes}
             onVotesRevealed={() => revealCards(room?.id ?? '')}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -172,7 +172,9 @@ pub async fn handle_reveal_cards(
     if let Ok(room_id) = Uuid::parse_str(&payload.room_id) {
         let mut rooms = app_state.rooms.lock().await;
         if let Some(room) = rooms.get_mut(&room_id) {
-            if room.host_id == socket.id.to_string() {
+            let all_voted = room.players.values().any(|p| p.has_voted);
+
+            if room.host_id == socket.id.to_string() && all_voted {
                 room.cards_revealed = true;
                 info!("Cards revealed in room {}", room_id_str);
 
@@ -184,10 +186,7 @@ pub async fn handle_reveal_cards(
                     error!("Failed to notify cards revealed: {}", err);
                 }
             } else {
-                error!(
-                    "Player {} is not the host of room {}",
-                    socket.id, room_id_str
-                );
+                error!("Cannot reveal cards for room {}", room_id_str);
             }
         }
     }


### PR DESCRIPTION
disables the vote button in the UI until at least 1 player has voted, also prevents the backend `cardsRevealed` event firing unless 1 person in the room has voted

also adds caching to some of the workflows

also adds some misc github files

resolves: #43