### PR TITLE
fix: prevent players joining nonexistent rooms

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -11,6 +11,7 @@
 
 .Dialog-overlay {
   background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(10px);
   display: grid;
   place-items: center;
 }

--- a/frontend/src/components/room-headline.component.tsx
+++ b/frontend/src/components/room-headline.component.tsx
@@ -37,7 +37,12 @@ function RoomHeadline({
         </AppBar.ToolbarTrail>
       </AppBar.Toolbar>
       <AppBar.Headline>
-        <h2 className="h2">Room: {roomId}</h2>
+        <h2 className="h2">
+          Room:{' '}
+          <span>
+            {roomId === '' ? 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' : roomId}
+          </span>
+        </h2>
         <p>
           You are logged in as{' '}
           <span className="font-semibold">{playerName}</span>&nbsp;(

--- a/frontend/src/components/room-headline.stories.tsx
+++ b/frontend/src/components/room-headline.stories.tsx
@@ -39,3 +39,11 @@ export const IsHost: Story = {
     exitRoom: fn(),
   },
 };
+
+export const EmptyRoomId: Story = {
+  args: {
+    roomId: '',
+    isHost: true,
+    playerName: 'Alice',
+  },
+};

--- a/frontend/src/providers/socket.provider.tsx
+++ b/frontend/src/providers/socket.provider.tsx
@@ -78,6 +78,7 @@ function SocketProvider({ children }: Readonly<{ children: React.ReactNode }>) {
       me,
       setMe,
       error,
+      setError,
       joinRoom,
       exitRoom,
       createRoom,
@@ -90,6 +91,7 @@ function SocketProvider({ children }: Readonly<{ children: React.ReactNode }>) {
       me,
       setMe,
       error,
+      setError,
       joinRoom,
       exitRoom,
       createRoom,
@@ -163,7 +165,8 @@ function SocketProvider({ children }: Readonly<{ children: React.ReactNode }>) {
     });
 
     socket.on('roomNotFound', () => {
-      setError('Room not found or invalid ID.');
+      setError('Sorry, that room does not exist');
+      navigate({ to: '/' });
     });
 
     socket.on('playerDisconnected', (room) => {

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Tabs } from '@skeletonlabs/skeleton-react';
 import { createFileRoute } from '@tanstack/react-router';
@@ -7,15 +7,25 @@ import { useSocket } from '../hooks/socket.hook';
 import { Logo } from '../components/logo.component';
 import { JoinRoomForm } from '../components/join-room-form.component';
 import { CreateRoomForm } from '../components/create-room-form.component';
+import { toaster } from '../contexts/toaster.context';
 
 export const Route = createFileRoute('/')({
   component: Index,
 });
 
 function Index() {
-  const { error, joinRoom, createRoom } = useSocket();
+  const { error, joinRoom, createRoom, setError } = useSocket();
 
   const [createJoin, setCreateJoin] = useState('create');
+
+  useEffect(() => {
+    if (error) {
+      setTimeout(() => {
+        toaster.error({ title: 'Error', description: error });
+        setError('');
+      }, 0);
+    }
+  }, [error, setError]);
 
   return (
     <div className="flex flex-col items-center justify-center p-8 space-y-4">
@@ -24,7 +34,6 @@ function Index() {
         <h1 className="h1">Storypoint Shuffle</h1>
       </div>
       <p className="">Create a new room or join an existing one.</p>
-      {error && <div className="text-error-500">{error}</div>}
 
       <Tabs
         value={createJoin}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -54,6 +54,7 @@ export interface AppState {
   me?: Player;
   setMe: Dispatch<SetStateAction<Player | undefined>>;
   error?: string;
+  setError: Dispatch<SetStateAction<string | undefined>>;
   joinRoom: (roomId: string, name: string) => void;
   exitRoom: (roomId: string, playerId: string) => void;
   createRoom: (name: string) => void;


### PR DESCRIPTION
## Description

route to home and show an error if the player attempts to join a room that doesnt exist also adds background blur to dialog and default room name to make the ui a bit better

Resolves #30

---

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

---

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Include any relevant details for your test configuration. -->

- [X] Local build
- [X] Manual testing

---

## Checklist

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes


